### PR TITLE
Using `lock` on `SharedMemoryDict.clear()` method and simplify it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+[NEXT_RELEASE]
+------------------
+- Using lock on method `SharedMemoryDict.clear()`
+
 0.1.1 (2020-08-12)
 ------------------
 - Fix typo on hooks

--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -22,9 +22,9 @@ class SharedMemoryDict(OrderedDict):
         with self._modify_db() as db:
             db.move_to_end(key, last=last)
 
+    @lock
     def clear(self) -> None:
-        with self._modify_db() as db:
-            db.clear()
+        self._save_memory(OrderedDict())
 
     def popitem(self, last: Optional[bool] = True) -> Any:
         with self._modify_db() as db:


### PR DESCRIPTION
In some scenarios using django adapter, SharedMemoryDict raise strange errors, f.ex:
```
builtins:UnicodeDecodeError: 'utf-8' codec can't decode byte 0x94 in position 29: invalid start byte
```
And in this case, we can't call `cache.clear()` 'cause the memory area is corrupted.

So I add lock on that method and simplify it added a fresh new OrderedDict on memory instead of reading, unpickle and call OrderedDict.clear().

I can't reproduce that strange behavior, if anyone has any idea I can add some tests.