### PR TITLE
Remove uWSGI Lock and using multiprocessing.Lock instead

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,5 +39,8 @@ jobs:
       - name: Lints
         run: make lint
 
+      - name: Unit Tests With Locks
+        run: SHARED_MEMORY_USE_LOCK=1 make test
+
       - name: Unit Tests
         run: make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+[NEXT_RELASE]
+------------------
+- Remove uwsgi lock and use `multiprocessing.Lock` instead
+
 0.2.0 (2020-10-19)
 ------------------
 - Using lock on method `SharedMemoryDict.clear()`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install shared-memory-dict
 ```
 
 ## Locks
-To use [uwsgidecorators.lock](https://uwsgi-docs.readthedocs.io/en/latest/PythonDecorators.html#uwsgidecorators.lock) on write operations of shared memory dict set environment variable `SHARED_MEMORY_USE_UWSGI_LOCK`.
+To use [multiprocessing.Lock](https://docs.python.org/3.8/library/multiprocessing.html#multiprocessing.Lock) on write operations of shared memory dict set environment variable `SHARED_MEMORY_USE_LOCK=1`.
 
 ## Django Cache Implementation
 There's a [Django Cache Implementation](https://docs.djangoproject.com/en/3.0/topics/cache/) with Shared Memory Dict:

--- a/shared_memory_dict/lock.py
+++ b/shared_memory_dict/lock.py
@@ -1,15 +1,28 @@
 import os
 from functools import wraps
 
-if os.getenv('SHARED_MEMORY_USE_UWSGI_LOCK') == '1':
-    from uwsgidecorators import lock
+if os.getenv('SHARED_MEMORY_USE_LOCK') == '1':
+    from multiprocessing import Lock
 else:
 
-    def _dummy_lock(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
+    class Lock:  # type: ignore
+        def acquire(self):
+            pass
+
+        def release(self):
+            pass
+
+
+_lock = Lock()
+
+
+def lock(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        _lock.acquire()
+        try:
             return func(*args, **kwargs)
+        finally:
+            _lock.release()
 
-        return wrapper
-
-    lock = _dummy_lock
+    return wrapper


### PR DESCRIPTION
I can't reproduce tests with uWSGI locks so I removed it and start using python `multiprocessing.Lock` (and now it's possible to use locks in gunicorn envs)