### PR TITLE
fixing the Python 3.8 resource_tracker.py:216: UserWarning: resource_…

### DIFF
--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -17,6 +17,7 @@ class SharedMemoryDict(OrderedDict):
 
     def cleanup(self) -> None:
         self._memory_block.close()
+        self._memory_block.unlink()
 
     def move_to_end(self, key: str, last: Optional[bool] = True) -> None:
         with self._modify_db() as db:


### PR DESCRIPTION
fixing the issue #13 , "UserWarning: resource_tracker: There appear to be 1 leaked shared_memory objects to clean up at shutdown"