### PR TITLE
Use dict instead of OrderedDict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 [NEXT_RELEASE]
 --------------
 - Configure black as formatter
+- Implement Mapping interface (all methods)
+- Deprecate `move_to_end and` method and `last` parameter on `popitem`
 
 0.4.0 (2020-11-09)
 ------------------

--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -18,6 +18,9 @@ from .lock import lock
 from .templates import MEMORY_NAME
 
 
+SENTINEL = object()
+
+
 class SharedMemoryDict:
     def __init__(self, name: str, size: int) -> None:
         super().__init__()
@@ -123,9 +126,7 @@ class SharedMemoryDict:
     def items(self) -> ItemsView:  # type: ignore
         return self._read_memory().items()
 
-    __SENTINEL = object()
-
-    def pop(self, key: str, default: Optional[Any] = __SENTINEL):
+    def pop(self, key: str, default: Optional[Any] = SENTINEL):
         with self._modify_db() as db:
             if default is self.__SENTINEL:
                 return db.pop(key)

--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -133,7 +133,7 @@ class SharedMemoryDict:
 
     def update(self, other=(), /, **kwds):
         with self._modify_db() as db:
-            return db.update(other, **kwds)
+            db.update(other, **kwds)
 
     def setdefault(self, key: str, default: Optional[Any] = None):
         with self._modify_db() as db:

--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -19,8 +19,8 @@ from .templates import MEMORY_NAME
 
 
 class SharedMemoryDict:
-    def __init__(self, name: str, size: int, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, name: str, size: int) -> None:
+        super().__init__()
         self._memory_block = self._get_or_create_memory_block(
             MEMORY_NAME.format(name=name), size
         )
@@ -93,6 +93,7 @@ class SharedMemoryDict:
         return self._read_memory() != other
 
     if sys.version_info > (3, 8):
+
         def __or__(self, other: Any):
             return self._read_memory() | other
 
@@ -138,7 +139,9 @@ class SharedMemoryDict:
         with self._modify_db() as db:
             return db.setdefault(key, default)
 
-    def _get_or_create_memory_block(self, name: str, size: int) -> SharedMemory:
+    def _get_or_create_memory_block(
+        self, name: str, size: int
+    ) -> SharedMemory:
         try:
             return SharedMemory(name=name)
         except FileNotFoundError:

--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -123,11 +123,11 @@ class SharedMemoryDict:
     def items(self) -> ItemsView:  # type: ignore
         return self._read_memory().items()
 
-    __marker = object()
+    __SENTINEL = object()
 
-    def pop(self, key: str, default: Optional[Any] = __marker):
+    def pop(self, key: str, default: Optional[Any] = __SENTINEL):
         with self._modify_db() as db:
-            if default is self.__marker:
+            if default is self.__SENTINEL:
                 return db.pop(key)
             return db.pop(key, default)
 

--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -17,7 +17,6 @@ from typing import (
 from .lock import lock
 from .templates import MEMORY_NAME
 
-
 SENTINEL = object()
 
 

--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -30,8 +30,8 @@ class SharedMemoryDict:
 
     def move_to_end(self, key: str, last: Optional[bool] = True) -> None:
         warnings.warn(
-            "The 'move_to_end' method will be removed in future versions. "
-            "Use pop and reassignment instead.",
+            'The \'move_to_end\' method will be removed in future versions. '
+            'Use pop and reassignment instead.',
             DeprecationWarning,
             stacklevel=2,
         )
@@ -45,8 +45,8 @@ class SharedMemoryDict:
     def popitem(self, last: Optional[bool] = None) -> Any:
         if last is not None:
             warnings.warn(
-                "The 'last' parameter will be removed in future versions. "
-                "The 'popitem' function now always returns last inserted.",
+                'The \'last\' parameter will be removed in future versions. '
+                'The \'popitem\' function now always returns last inserted.',
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -128,7 +128,7 @@ class SharedMemoryDict:
 
     def pop(self, key: str, default: Optional[Any] = SENTINEL):
         with self._modify_db() as db:
-            if default is self.__SENTINEL:
+            if default is SENTINEL:
                 return db.pop(key)
             return db.pop(key, default)
 

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -8,24 +8,24 @@ from shared_memory_dict import SharedMemoryDict
 class TestSharedMemoryDict:
     @pytest.fixture
     def shared_memory_dict(self):
-        smd = SharedMemoryDict(name="ut", size=1024)
+        smd = SharedMemoryDict(name='ut', size=1024)
         yield smd
         smd.clear()
         smd.cleanup()
 
     @pytest.fixture
     def key(self):
-        return "fake-key"
+        return 'fake-key'
 
     @pytest.fixture
     def value(self):
-        return "fake-value"
+        return 'fake-value'
 
     def test_should_add_a_key(self, shared_memory_dict, key, value):
         try:
             shared_memory_dict[key] = value
         except Exception as e:
-            pytest.fail(f"Its should not raises: {e}")
+            pytest.fail(f'Its should not raises: {e}')
 
     def test_should_read_a_key(self, shared_memory_dict, key, value):
         shared_memory_dict[key] = value
@@ -34,7 +34,7 @@ class TestSharedMemoryDict:
     def test_should_read_a_key_with_default(
         self, shared_memory_dict, key, value
     ):
-        default_value = "default_value"
+        default_value = 'default_value'
         assert shared_memory_dict.get(key, default_value) == default_value
 
     def test_should_read_a_key_without_default(
@@ -47,7 +47,7 @@ class TestSharedMemoryDict:
         try:
             del shared_memory_dict[key]
         except Exception as e:
-            pytest.fail(f"Its should not raises: {e}")
+            pytest.fail(f'Its should not raises: {e}')
 
         with pytest.raises(KeyError):
             shared_memory_dict[key]
@@ -66,22 +66,22 @@ class TestSharedMemoryDict:
         try:
             shared_memory_dict.clear()
         except Exception as e:
-            pytest.fail(f"Its should not raises: {e}")
+            pytest.fail(f'Its should not raises: {e}')
 
         with pytest.raises(KeyError):
             shared_memory_dict[key]
 
     def test_should_finalize_dict(self):
-        smd = SharedMemoryDict(name="unit-tests", size=64)
+        smd = SharedMemoryDict(name='unit-tests', size=64)
         try:
             del smd
         except Exception as e:
-            pytest.fail(f"Its should not raises: {e}")
+            pytest.fail(f'Its should not raises: {e}')
 
     def test_should_check_item_in_dict(self, shared_memory_dict, key, value):
         shared_memory_dict[key] = value
         assert (key in shared_memory_dict) is True
-        assert ("some-another-key" in shared_memory_dict) is False
+        assert ('some-another-key' in shared_memory_dict) is False
 
     def test_should_return_dict_keys(self, shared_memory_dict, key, value):
         shared_memory_dict[key] = value
@@ -128,14 +128,14 @@ class TestSharedMemoryDict:
         assert shared_memory_dict != {value: key}
 
     @pytest.mark.skipif(
-        sys.version_info < (3, 9), reason="requires python3.9 or higher"
+        sys.version_info < (3, 9), reason='requires python3.9 or higher'
     )
     def test_allow_dict_merge(self, shared_memory_dict, key, value):
         assert shared_memory_dict | {key: value} == {key: value}
         assert {key: value} | shared_memory_dict == {key: value}
 
     @pytest.mark.skipif(
-        sys.version_info < (3, 9), reason="requires python3.9 or higher"
+        sys.version_info < (3, 9), reason='requires python3.9 or higher'
     )
     def test_allow_dict_update(self, shared_memory_dict, key, value):
         shared_memory_dict |= {key: value}
@@ -165,8 +165,8 @@ class TestSharedMemoryDict:
 
     def test_pop_an_item_with_default(self, shared_memory_dict, key, value):
         shared_memory_dict[key] = value
-        default = "default"
-        assert shared_memory_dict.pop("unknown", default) == default
+        default = 'default'
+        assert shared_memory_dict.pop('unknown', default) == default
 
     def test_can_be_updated(self, shared_memory_dict, key, value):
         shared_memory_dict.update({key: value})

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -84,3 +84,25 @@ class TestSharedMemoryDict:
     def test_should_return_dict_keys(self, shared_memory_dict, key, value):
         shared_memory_dict[key] = value
         assert list(shared_memory_dict.keys()) == [key]
+
+    def test_should_warning_about_move_to_end_deprecation(
+        self, shared_memory_dict, key, value
+    ):
+        shared_memory_dict[key] = value
+        deprecation_message = (
+            "The 'move_to_end' method will be removed in future versions. "
+            "Use pop and reassignment instead."
+        )
+        with pytest.deprecated_call(match=deprecation_message):
+            shared_memory_dict.move_to_end(key)
+
+    def test_should_warning_about_last_parameter_deprecation_in_popitem(
+        self, shared_memory_dict, key, value
+    ):
+        shared_memory_dict[key] = value
+        deprecation_message = (
+            "The 'last' parameter will be removed in future versions. "
+            "The 'popitem' function now always returns last inserted."
+        )
+        with pytest.deprecated_call(match=deprecation_message):
+            shared_memory_dict.popitem(last=True)

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -92,8 +92,8 @@ class TestSharedMemoryDict:
     ):
         shared_memory_dict[key] = value
         deprecation_message = (
-            "The 'move_to_end' method will be removed in future versions. "
-            "Use pop and reassignment instead."
+            'The \'move_to_end\' method will be removed in future versions. '
+            'Use pop and reassignment instead.'
         )
         with pytest.deprecated_call(match=deprecation_message):
             shared_memory_dict.move_to_end(key)
@@ -103,8 +103,8 @@ class TestSharedMemoryDict:
     ):
         shared_memory_dict[key] = value
         deprecation_message = (
-            "The 'last' parameter will be removed in future versions. "
-            "The 'popitem' function now always returns last inserted."
+            'The \'last\' parameter will be removed in future versions. '
+            'The \'popitem\' function now always returns last inserted.'
         )
         with pytest.deprecated_call(match=deprecation_message):
             shared_memory_dict.popitem(last=True)


### PR DESCRIPTION
- feat: deprecate OrderedDict interface
- feat: implements mapping interface
- fix: Too many arguments for '__init__' of 'object'
- fix: update return nothing
- feat: add tests for SharedMemoryDict new methods
- feat: document changes

closes #15 and closes #17

closes #16 


**benchmarks**

before:
![image](https://user-images.githubusercontent.com/3127847/107094206-61bed480-67e5-11eb-8b7c-ee751ada87b2.png)

after:
![image](https://user-images.githubusercontent.com/3127847/107094367-a64a7000-67e5-11eb-8fe0-302eed0abffd.png)

before:
![image](https://user-images.githubusercontent.com/3127847/107094501-dbef5900-67e5-11eb-9d98-c7142a91c967.png)

after:
![image](https://user-images.githubusercontent.com/3127847/107094536-ec073880-67e5-11eb-8cb1-7f6b1ecbf401.png)


before:
![image](https://user-images.githubusercontent.com/3127847/107094640-240e7b80-67e6-11eb-898f-07ffcf8d3aaf.png)

after:
![image](https://user-images.githubusercontent.com/3127847/107094699-41434a00-67e6-11eb-9297-0729dd3a2548.png)