### PR TITLE
Add a better message on the storage issue

### DIFF
--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -149,7 +149,10 @@ class SharedMemoryDict:
 
     def _save_memory(self, db: Dict[str, Any]) -> None:
         data = pickle.dumps(db, pickle.HIGHEST_PROTOCOL)
-        self._memory_block.buf[: len(data)] = data  # type: ignore
+        try:
+            self._memory_block.buf[: len(data)] = data  # type: ignore
+        except ValueError as exc:
+            raise ValueError("exceeds available storage") from exc
 
     def _read_memory(self) -> Dict[str, Any]:
         try:

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -21,6 +21,10 @@ class TestSharedMemoryDict:
     def value(self):
         return 'fake-value'
 
+    @pytest.fixture
+    def big_value(self):
+        return 'value' * 2048
+
     def test_should_add_a_key(self, shared_memory_dict, key, value):
         try:
             shared_memory_dict[key] = value
@@ -177,3 +181,7 @@ class TestSharedMemoryDict:
     ):
         shared_memory_dict.setdefault(key, value)
         assert shared_memory_dict[key] == value
+
+    def test_raise_an_error_when_memory_is_full(self, shared_memory_dict, key, big_value):
+        with pytest.raises(ValueError, match="exceeds available storage"):
+            shared_memory_dict[key] = big_value


### PR DESCRIPTION
Before: 
```
ValueError: memoryview assignment: lvalue and rvalue have different structures
```

After:
```
ValueError: exceeds available storage
```

related to #25 

Related to 