### PR TITLE
Expose shared memory as readonly attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,31 @@ A very simple [shared memory](https://docs.python.org/3/library/multiprocessing.
 **Requires**: Python >= 3.8
 
 ```python
+>>> # In the first Python interactive shell
 >> from shared_memory_dict import SharedMemoryDict
 >> smd = SharedMemoryDict(name='tokens', size=1024)
 >> smd['some-key'] = 'some-value-with-any-type'
 >> smd['some-key']
 'some-value-with-any-type'
+
+>>> # In either the same shell or a new Python shell on the same machine
+>> existing_smd = SharedMemoryDict(name='tokens', size=1024)
+>>> existing_smd['some-key']
+'some-value-with-any-type'
+>>> existing_smd['new-key'] = 'some-value-with-any-type'
+
+
+>>> # Back in the first Python interactive shell, smd reflects this change
+>> smd['new-key']
+'some-value-with-any-type'
+
+>>> # Clean up from within the second Python shell
+>>> existing_smd.shm.close()  # or "del existing_smd"
+
+>>> # Clean up from within the first Python shell
+>>> smd.shm.close()
+>>> smd.shm.unlink()  # Free and release the shared memory block at the very end
+>>> del smd  # use of smd after call unlink() is unsupported
 ```
 
 > The arg `name` defines the location of the memory block, so if you want to share the memory between process use the same name

--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -159,3 +159,7 @@ class SharedMemoryDict:
             return pickle.loads(self._memory_block.buf)
         except pickle.UnpicklingError:
             return {}
+
+    @property
+    def shm(self) -> SharedMemory:
+        return self._memory_block

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -185,3 +185,13 @@ class TestSharedMemoryDict:
     def test_raise_an_error_when_memory_is_full(self, shared_memory_dict, key, big_value):
         with pytest.raises(ValueError, match="exceeds available storage"):
             shared_memory_dict[key] = big_value
+    
+    def test_should_expose_shared_memory(self, shared_memory_dict):
+        try:
+            shared_memory_dict.shm
+        except AttributeError:
+            pytest.fail('Should expose shared memory')
+
+    def test_shared_memory_attribute_should_be_read_only(self, shared_memory_dict):
+        with pytest.raises(AttributeError):
+            shared_memory_dict.shm = 'test'


### PR DESCRIPTION
- Expose shared memory as readonly attribute as ShareableList
- Improve README with more examples and calls to close and unlink
