### PR TITLE
fix[JSONSerializer]: fix unserializing of JSON data

### DIFF
--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -40,6 +40,8 @@ class SharedMemoryDict:
         )
 
     def cleanup(self) -> None:
+        if not hasattr(self, '_memory_block'):
+            return
         self._memory_block.close()
 
     def move_to_end(self, key: str, last: Optional[bool] = True) -> None:

--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -157,7 +157,10 @@ class SharedMemoryDict:
         try:
             return SharedMemory(name=name)
         except FileNotFoundError:
-            return SharedMemory(name=name, create=True, size=size)
+            shm = SharedMemory(name=name, create=True, size=size)
+            data = self._serializer.dumps({})
+            shm.buf[: len(data)] = data
+            return shm
 
     def _save_memory(self, db: Dict[str, Any]) -> None:
         data = self._serializer.dumps(db)
@@ -168,7 +171,7 @@ class SharedMemoryDict:
 
     def _read_memory(self) -> Dict[str, Any]:
         try:
-            return self._serializer.loads(self._memory_block.buf)
+            return self._serializer.loads(self._memory_block.buf.tobytes())
         except Exception as exc:
             logger.warning(f"Fail to load data: {exc!r}")
             return {}

--- a/shared_memory_dict/serializers.py
+++ b/shared_memory_dict/serializers.py
@@ -1,6 +1,8 @@
 import json
 import pickle
-from typing import Protocol
+from typing import Final, Protocol
+
+NULL_BYTE: Final = b"\x00"
 
 
 class SharedMemoryDictSerializer(Protocol):
@@ -13,9 +15,10 @@ class SharedMemoryDictSerializer(Protocol):
 
 class JSONSerializer:
     def dumps(self, obj: dict) -> bytes:
-        return json.dumps(obj).encode()
+        return json.dumps(obj).encode() + NULL_BYTE
 
     def loads(self, data: bytes) -> dict:
+        data = bytes(data).split(NULL_BYTE, 1)[0]
         return json.loads(data)
 
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -37,7 +37,7 @@ class TestJSONSerializer:
 
     @pytest.fixture
     def bytes_content(self):
-        return b'{"key": "value"}'
+        return b'{"key": "value"}\x00'
 
     @pytest.fixture
     def dict_content(self):


### PR DESCRIPTION
1. The json module does not support memoryview() objects to load().

```
>>> import shared_memory_dict
>>> s = shared_memory_dict.SharedMemoryDict('test', 1000, serializer=shared_memory_dict.serializers.JSONSerializer())
>>> s
Fail to load data: TypeError('the JSON object must be str, bytes or bytearray, not memoryview')
{}
>>> s['foo']  = 1
Fail to load data: TypeError('the JSON object must be str, bytes or bytearray, not memoryview')
>>> s
Fail to load data: TypeError('the JSON object must be str, bytes or bytearray, not memoryview')
{}
```

2. The memoryview() data initially contains only null bytes (with the size of the data)

3. If the size decreases, the memory is not overwritten with null bytes.
    Therefore invalid JSON data is part of the memory.
    Always append a null byte to the dumped data and read only until a null
    byte when loading data.

Fixes: d1a564d24ae474d0f1f1d5ff2e16bdf2047919a9

It seems this was never tested - just a broken test case has been added, which I adjusted to more real behavior.
Please also consider my hint https://github.com/luizalabs/shared-memory-dict/commit/77fafc916e62ebd5636a379ee337e3b6158aa1eb#r58780191 - which would have covered this more easily.