### PR TITLE
feat[serializers]: specify default JSON encoders to make subclassing more easily

### DIFF
--- a/shared_memory_dict/serializers.py
+++ b/shared_memory_dict/serializers.py
@@ -15,6 +15,8 @@ class SharedMemoryDictSerializer(Protocol):
 
 class JSONSerializer:
 
+    __slots__ = ()
+
     encoder = json.JSONEncoder
     decoder = json.JSONDecoder
 
@@ -27,6 +29,9 @@ class JSONSerializer:
 
 
 class PickleSerializer:
+
+    __slots__ = ()
+
     def dumps(self, obj: dict) -> bytes:
         return pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
 

--- a/shared_memory_dict/serializers.py
+++ b/shared_memory_dict/serializers.py
@@ -14,12 +14,16 @@ class SharedMemoryDictSerializer(Protocol):
 
 
 class JSONSerializer:
+
+    encoder = json.JSONEncoder
+    decoder = json.JSONDecoder
+
     def dumps(self, obj: dict) -> bytes:
-        return json.dumps(obj).encode() + NULL_BYTE
+        return json.dumps(obj, cls=self.encoder).encode() + NULL_BYTE
 
     def loads(self, data: bytes) -> dict:
         data = data.split(NULL_BYTE, 1)[0]
-        return json.loads(data)
+        return json.loads(data, cls=self.decoder)
 
 
 class PickleSerializer:


### PR DESCRIPTION
* feat[serializers]: specify default JSON encoders
→ make subclassing more easily

* feat[serializers]: specify empty __slots__ for serializer classes
* → a little bit gain of memory usage for multiple instances