### PR TITLE
Update dict.py to check if dictionary key exists

### DIFF
--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -77,7 +77,10 @@ class SharedMemoryDict:
         self._save_memory(db)
 
     def __getitem__(self, key: str) -> Any:
-        return self._read_memory()[key]
+        if  self.__contains__(key):
+            return self._read_memory()[key]
+        else:
+            return None
 
     def __setitem__(self, key: str, value: Any) -> None:
         with self._modify_db() as db:


### PR DESCRIPTION
Ensure dictionary key exists to support common .get() method with default when not existing. Current code throws keyerror even when using a smd.get('non-exist-key', 'default_value')