### PR TITLE
Update dict.py to check if dictionary key exists

### DIFF
--- a/shared_memory_dict/dict.py
+++ b/shared_memory_dict/dict.py
@@ -128,7 +128,10 @@ class SharedMemoryDict:
         return repr(self._read_memory())
 
     def get(self, key: str, default: Optional[Any] = None) -> Any:
-        return self._read_memory().get(key, default)
+        if self.__contains__(key):
+            return self._read_memory().get(key, default)
+        else:
+            return default
 
     def keys(self) -> KeysView[Any]:
         return self._read_memory().keys()


### PR DESCRIPTION
Ensure dictionary key exists to support common .get() method with default when not existing. Current code throws keyerror even when using a smd.get('non-exist-key', 'default_value')

Closes #51 